### PR TITLE
fix: prevent double-deduction for auto-loss non-voters

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -113,6 +113,20 @@ function openDb() {
       if (err) console.error('[MIGRATION] Failed to create password_reset_tokens table:', err);
       else console.log('✅ [MIGRATION] password_reset_tokens table ready');
     });
+
+    // Add is_auto_loss column to votes if missing
+    db.all('PRAGMA table_info(votes)', (err, cols) => {
+      if (err) { console.error('[MIGRATION] Failed to inspect votes table:', err); return; }
+      const hasCol = cols && cols.some(c => c.name === 'is_auto_loss');
+      if (!hasCol) {
+        db.run('ALTER TABLE votes ADD COLUMN is_auto_loss INTEGER DEFAULT 0', (e) => {
+          if (e) console.error('[MIGRATION] Failed to add is_auto_loss column:', e);
+          else console.log('✅ [MIGRATION] is_auto_loss column added to votes');
+        });
+      } else {
+        console.log('✅ [MIGRATION] is_auto_loss column already exists');
+      }
+    });
   });
 })();
 
@@ -3161,22 +3175,27 @@ app.post('/api/admin/matches/:id/winner', requireRole(['admin', 'superuser']), (
                   db.all('SELECT user_id, points FROM votes WHERE match_id = ? AND team != ?', [id, winner], (errLosers, loserVotes) => {
                     if (errLosers) { db.close(); return res.status(500).json({ error: 'DB error' }); }
 
+                    // Auto-loss users already had their balance deducted — skip them here to avoid double-charging
+                    const autoLossUserIds = new Set(nonVotedUsers.map(u => u.id));
+                    const realLoserVotes = (loserVotes || []).filter(v => !autoLossUserIds.has(v.user_id));
+
                     if (totalLoser === 0 || totalWinner === 0) {
-                      // Deduct losers even if no winners (or no losers if no losers)
-                      if ((loserVotes || []).length === 0) {
+                      // Deduct losers even if no winners (or no losers)
+                      if (realLoserVotes.length === 0) {
                         db.close();
                         return res.json({ ok: true, distributed: 0, autoLoss: nonVotedUsers.length });
                       }
-                      // Still deduct loser season balances
+                      // Still deduct real loser season balances (auto-loss already deducted above)
                       let losersProcessed = 0;
-                      loserVotes.forEach(v => {
+                      realLoserVotes.forEach(v => {
                         db.run('UPDATE user_seasons SET balance = balance - ? WHERE user_id = ? AND season_id = ?',
-                          [v.points, v.user_id, seasonId], () => { losersProcessed++; if (losersProcessed === loserVotes.length) { db.close(); return res.json({ ok: true, distributed: 0, autoLoss: nonVotedUsers.length }); } });
+                          [v.points, v.user_id, seasonId], () => { losersProcessed++; if (losersProcessed === realLoserVotes.length) { db.close(); return res.json({ ok: true, distributed: 0, autoLoss: nonVotedUsers.length }); } });
                       });
                       return;
                     }
 
-                    // Deduct loser season balances
+                    // Deduct real loser season balances (auto-loss users already deducted)
+                    const loserVotesToDeduct = realLoserVotes;
                     let losersProcessed = 0;
                     const afterLosersDeducted = () => {
                       // For each winner vote, compute net gain = (stake/totalWinner)*totalLoser (rounded)
@@ -3203,15 +3222,15 @@ app.post('/api/admin/matches/:id/winner', requireRole(['admin', 'superuser']), (
                       });
                     };
 
-                    if (loserVotes.length === 0) {
+                    if (loserVotesToDeduct.length === 0) {
                       afterLosersDeducted();
                       return;
                     }
-                    loserVotes.forEach(v => {
+                    loserVotesToDeduct.forEach(v => {
                       db.run('UPDATE user_seasons SET balance = balance - ? WHERE user_id = ? AND season_id = ?',
                         [v.points, v.user_id, seasonId], () => {
                           losersProcessed++;
-                          if (losersProcessed === loserVotes.length) afterLosersDeducted();
+                          if (losersProcessed === loserVotesToDeduct.length) afterLosersDeducted();
                         });
                     });
                   });
@@ -3231,7 +3250,7 @@ app.post('/api/admin/matches/:id/winner', requireRole(['admin', 'superuser']), (
             db.run('UPDATE user_seasons SET balance = balance - ? WHERE user_id = ? AND season_id = ?',
               [autoPoints, user.id, seasonId], (errBal) => {
                 if (errBal) console.error('Error deducting auto-loss season balance:', errBal);
-                db.run('INSERT INTO votes (match_id, user_id, team, points) VALUES (?, ?, ?, ?)',
+                db.run('INSERT INTO votes (match_id, user_id, team, points, is_auto_loss) VALUES (?, ?, ?, ?, 1)',
                   [id, user.id, losingTeam, autoPoints], (errVote) => {
                     if (errVote) console.error('Error creating auto-loss vote:', errVote);
                     autoVotesPending--;
@@ -3663,6 +3682,86 @@ app.get('/api/admin/users/:userId/season-balances', requireRole('admin'), (req, 
       if (err) return res.status(500).json({ error: 'DB error' });
       res.json(rows || []);
     });
+});
+
+// ========== Retroactive Auto-Loss Balance Fix ==========
+
+// POST /api/admin/fix-auto-loss-balances
+// Finds every vote that was created after the match started (i.e. auto-loss votes) and
+// was double-charged. Credits each affected user +10 per such vote, marks the vote so
+// the endpoint is idempotent (safe to call multiple times).
+app.post('/api/admin/fix-auto-loss-balances', requireRole('admin'), (req, res) => {
+  const db = openDb();
+
+  // Fetch all completed matches with a winner set
+  db.all('SELECT id, season_id, scheduled_at, winner FROM matches WHERE winner IS NOT NULL', [], (err, matches) => {
+    if (err) return res.status(500).json({ error: 'DB error fetching matches', details: err.message });
+    if (!matches || matches.length === 0) return res.json({ fixed: 0, details: [] });
+
+    const results = [];
+    let pending = matches.length;
+
+    function finish() {
+      pending--;
+      if (pending === 0) {
+        const totalFixed = results.reduce((s, r) => s + r.credited, 0);
+        res.json({ fixed: totalFixed, details: results });
+      }
+    }
+
+    matches.forEach(match => {
+      // Parse scheduled_at using our existing helper so we can compare timestamps
+      const matchDate = parseMatchDateTime(match.scheduled_at);
+      if (!matchDate) { finish(); return; }
+
+      // The voting window closes 30 min before the match.
+      // Auto-loss votes are inserted AFTER the match starts, so their
+      // created_at will be well after matchDate. We use a 25-min buffer
+      // to safely distinguish real late votes from auto-loss inserts.
+      const cutoff = new Date(matchDate.getTime() - 25 * 60 * 1000); // matchDate - 25min
+
+      // Find votes for this match that:
+      //   1. are on the losing team (team != winner)
+      //   2. were created at or after the cutoff (auto-loss timing)
+      //   3. have NOT yet been fixed (is_auto_loss = 0, meaning they predate our column)
+      const sql = `
+        SELECT v.id, v.user_id, v.points, v.created_at, v.is_auto_loss
+        FROM votes v
+        WHERE v.match_id = ?
+          AND v.team != ?
+          AND v.is_auto_loss = 0
+          AND datetime(v.created_at) >= datetime(?)
+      `;
+      const cutoffStr = cutoff.toISOString();
+
+      db.all(sql, [match.id, match.winner, cutoffStr], (err2, suspectVotes) => {
+        if (err2 || !suspectVotes || suspectVotes.length === 0) { finish(); return; }
+
+        let votePending = suspectVotes.length;
+        let credited = 0;
+
+        suspectVotes.forEach(vote => {
+          // Credit +10 (the amount that was double-deducted) to user's season balance
+          db.run(
+            'UPDATE user_seasons SET balance = balance + 10 WHERE user_id = ? AND season_id = ?',
+            [vote.user_id, match.season_id],
+            (errUpd) => {
+              if (!errUpd) {
+                credited++;
+                // Mark the vote so we never double-credit
+                db.run('UPDATE votes SET is_auto_loss = 1 WHERE id = ?', [vote.id]);
+              }
+              votePending--;
+              if (votePending === 0) {
+                results.push({ match_id: match.id, scheduled_at: match.scheduled_at, credited });
+                finish();
+              }
+            }
+          );
+        });
+      });
+    });
+  });
 });
 
 // ========== Email Settings Management ==========

--- a/backend/migrations.js
+++ b/backend/migrations.js
@@ -21,7 +21,7 @@ const db = new sqlite3.Database(DB_PATH, (err) => {
 
 function runMigrations() {
   let completed = 0;
-  const total = 2;
+  const total = 3;
 
   const allDone = () => {
     completed++;
@@ -90,6 +90,31 @@ function runMigrations() {
           console.error('[MIGRATION] Error adding email:', err);
         } else {
           console.log('[MIGRATION] ✅ Added email column');
+        }
+        allDone();
+      });
+    }
+  });
+
+  // Migration 3: Add is_auto_loss column to votes
+  console.log('[MIGRATION] Checking for is_auto_loss column...');
+  db.all(`PRAGMA table_info(votes)`, (err, columns) => {
+    if (err) {
+      console.error('[MIGRATION] Error checking votes columns:', err);
+      allDone();
+      return;
+    }
+    const hasAutoLoss = columns && columns.some(c => c.name === 'is_auto_loss');
+    if (hasAutoLoss) {
+      console.log('[MIGRATION] ✅ is_auto_loss column already exists');
+      allDone();
+    } else {
+      console.log('[MIGRATION] ⚠️  is_auto_loss column missing, adding...');
+      db.run('ALTER TABLE votes ADD COLUMN is_auto_loss INTEGER DEFAULT 0', (err) => {
+        if (err) {
+          console.error('[MIGRATION] Error adding is_auto_loss:', err);
+        } else {
+          console.log('[MIGRATION] ✅ Added is_auto_loss column');
         }
         allDone();
       });

--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -1536,6 +1536,31 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
               </div>
             )}
           </section>
+          <section style={{background: 'rgba(255,255,255,0.72)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', borderRadius: '16px', padding: '22px', marginBottom: '20px', boxShadow: '0 4px 24px rgba(0,0,0,0.08)', border: '1px solid rgba(255,255,255,0.55)'}}>
+            <h3 style={{color: '#1a1a1a', marginTop: '0', marginBottom: '8px', fontSize: '18px', fontWeight: 'bold'}}>🔧 Data Maintenance</h3>
+            <p style={{color: '#666', fontSize: '14px', marginBottom: '16px'}}>
+              Run one-time fixes for known data issues. These operations are safe to run multiple times — they won't double-credit users.
+            </p>
+            <div style={{display: 'flex', alignItems: 'center', gap: '12px', flexWrap: 'wrap'}}>
+              <button
+                onClick={async () => {
+                  if (!window.confirm('This will find all users who were double-charged by the auto-loss bug and credit them +10 per affected match. Safe to run multiple times. Proceed?')) return;
+                  try {
+                    const resp = await axios.post('/api/admin/fix-auto-loss-balances', {}, { headers: { 'x-user': user.username } });
+                    const { fixed, details } = resp.data;
+                    const summary = details.filter(d => d.credited > 0).map(d => `Match ${d.match_id} (${d.scheduled_at}): ${d.credited} users credited`).join('\n') || 'No users needed fixing.';
+                    alert(`Fix complete.\nTotal credits applied: ${fixed}\n\n${summary}`);
+                  } catch (e) {
+                    alert('Error running fix: ' + (e.response?.data?.error || e.message));
+                  }
+                }}
+                style={{background: '#e67e22', color: 'white', border: 'none', borderRadius: '8px', padding: '10px 20px', fontWeight: 'bold', cursor: 'pointer', fontSize: '14px'}}
+              >
+                Fix Double-Charged Auto-Loss Users
+              </button>
+              <span style={{color: '#888', fontSize: '13px'}}>Credits +10 to users incorrectly charged twice when they didn't vote</span>
+            </div>
+          </section>
         </>
       )}
 


### PR DESCRIPTION
- Filter auto-loss users from loser distribution to avoid charging twice
- Add is_auto_loss column to votes table via startup migration
- Mark auto-loss votes with is_auto_loss=1 on insertion
- Add POST /api/admin/fix-auto-loss-balances retroactive fix endpoint
- Add Data Maintenance section in Admin > Users tab with fix button