### PR TITLE
chore: split deployment into separate frontend and backend workflows

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,27 @@
+name: Deploy Backend to Fly.io
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/**'
+      - '.github/workflows/deploy-backend.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy Backend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        working-directory: backend
+        run: flyctl deploy --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,4 +1,4 @@
-name: Deploy to Cloudflare Pages
+name: Deploy Frontend to Cloudflare Pages
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - 'frontend/**'
-      - '.github/workflows/deploy.yml'
+      - '.github/workflows/deploy-frontend.yml'
 
 jobs:
   deploy:


### PR DESCRIPTION
- Rename deploy.yml → deploy-frontend.yml (Cloudflare Pages, triggers on frontend/**)
- Add deploy-backend.yml (Fly.io, triggers on backend/**)
- Each workflow only runs when its own files change
- Requires FLY_API_TOKEN secret in GitHub repo settings