### PR TITLE
fix: hide sticky save bar while matches are loading

### DIFF
--- a/frontend/src/Matches.jsx
+++ b/frontend/src/Matches.jsx
@@ -366,7 +366,7 @@ export default function Matches({ seasonId, user, refreshUser, refreshTrigger })
   })
 
   return (
-    <div style={{padding: isMobile ? '12px' : '20px', paddingBottom: pendingCount > 0 ? '80px' : undefined, minHeight: '100vh'}}>
+    <div style={{padding: isMobile ? '12px' : '20px', paddingBottom: !loading && pendingCount > 0 ? '80px' : undefined, minHeight: '100vh'}}>
       <div style={{
         display: 'flex', alignItems: isMobile ? 'flex-start' : 'center',
         flexDirection: isMobile ? 'column' : 'row',
@@ -659,7 +659,7 @@ export default function Matches({ seasonId, user, refreshUser, refreshTrigger })
       {coinFlip.show && <CoinFlip teamName={coinFlip.team} />}
 
       {/* ── Sticky Save Bar ── */}
-      {user?.role !== 'admin' && pendingCount > 0 && (
+      {user?.role !== 'admin' && !loading && pendingCount > 0 && (
         <div style={{
           position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 200,
           background: 'rgba(10,20,35,0.96)',


### PR DESCRIPTION
Prevents the save bar from briefly appearing during the loading window where votes is populated per-match but userVotes hasn't been set yet.