### PR TITLE
fix: exclude NO_RESULT matches from user analytics + migrate to sjc

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -4,7 +4,7 @@
 #
 
 app = 'cricketmela-api'
-primary_region = 'lax'
+primary_region = 'sjc'
 
 [build]
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2650,8 +2650,8 @@ app.get('/api/analytics/overview/:userId', requireRole('picker', 'superuser', 'a
   const overallQuery = `
     SELECT 
       COUNT(*) as total_votes,
-      COUNT(CASE WHEN v.team = m.winner THEN 1 END) as won,
-      COUNT(CASE WHEN m.winner IS NOT NULL AND v.team != m.winner THEN 1 END) as lost,
+      COUNT(CASE WHEN v.team = m.winner AND m.winner != 'NO_RESULT' THEN 1 END) as won,
+      COUNT(CASE WHEN m.winner IS NOT NULL AND m.winner != 'NO_RESULT' AND v.team != m.winner THEN 1 END) as lost,
       SUM(v.points) as total_bet,
       AVG(v.points) as avg_bet
     FROM votes v
@@ -2667,7 +2667,7 @@ app.get('/api/analytics/overview/:userId', requireRole('picker', 'superuser', 'a
       SELECT v.match_id, v.points, v.team, m.winner
       FROM votes v
       JOIN matches m ON v.match_id = m.id
-      WHERE v.user_id = ? AND m.winner IS NOT NULL
+      WHERE v.user_id = ? AND m.winner IS NOT NULL AND m.winner != 'NO_RESULT'
     `, [userId], (err2, userVotes) => {
       if (err2) { db.close(); return res.status(500).json({ error: err2.message }); }
 


### PR DESCRIPTION
- Fix analytics overview endpoint to exclude NO_RESULT matches from won/lost counts and net profit (they were incorrectly counted as losses)
- Update fly.toml primary_region from lax to sjc due to lax zone outage