### PR TITLE
feat: add multi-sport support and rebrand to Sports Mela

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -177,14 +177,22 @@ function parseMatchDateTime(value) {
     monthIndex = parseInt(isoDate[2], 10) - 1;
     day = parseInt(isoDate[3], 10);
   } else {
-    const dmy = datePart.match(/^(\d{1,2})-([A-Za-z]{3})-(\d{2}|\d{4})$/);
-    if (!dmy) return null;
-    day = parseInt(dmy[1], 10);
-    const monthKey = dmy[2].toLowerCase();
-    if (monthMap[monthKey] === undefined) return null;
-    monthIndex = monthMap[monthKey];
-    const yearRaw = dmy[3];
-    year = yearRaw.length === 2 ? 2000 + parseInt(yearRaw, 10) : parseInt(yearRaw, 10);
+    // Handle DD/MM/YYYY or D/M/YYYY (slash-separated, day first — FIFA/international format)
+    const slashDmy = datePart.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (slashDmy) {
+      day = parseInt(slashDmy[1], 10);
+      monthIndex = parseInt(slashDmy[2], 10) - 1;
+      year = parseInt(slashDmy[3], 10);
+    } else {
+      const dmy = datePart.match(/^(\d{1,2})-([A-Za-z]{3})-(\d{2}|\d{4})$/);
+      if (!dmy) return null;
+      day = parseInt(dmy[1], 10);
+      const monthKey = dmy[2].toLowerCase();
+      if (monthMap[monthKey] === undefined) return null;
+      monthIndex = monthMap[monthKey];
+      const yearRaw = dmy[3];
+      year = yearRaw.length === 2 ? 2000 + parseInt(yearRaw, 10) : parseInt(yearRaw, 10);
+    }
   }
 
   const timePart = timePartRaw.trim();
@@ -200,8 +208,9 @@ function parseMatchDateTime(value) {
     if (ampm === 'PM') hour += 12;
   }
 
-  // YYYY-MM-DD + 24h format is treated as UTC (CricAPI GMT); other formats stay local.
-  if (isoDate && !ampm) {
+  // 24h time (no AM/PM) → treat as UTC (covers ISO dates and slash/FIFA dates in GMT)
+  // AM/PM times → local time (cricket CSVs stored in IST)
+  if (!ampm) {
     return new Date(Date.UTC(year, monthIndex, day, hour, minute, second, 0));
   }
   return new Date(year, monthIndex, day, hour, minute, second, 0);
@@ -405,6 +414,17 @@ function initializeDatabase() {
         });
       } else {
         console.log('✅ seasons.cricbuzz_series_id column already exists');
+      }
+
+      // Migration: Add sport column to seasons if it doesn't exist
+      const hasSport = columns && columns.some(c => c.name === 'sport');
+      if (!hasSport) {
+        db.run(`ALTER TABLE seasons ADD COLUMN sport TEXT DEFAULT 'cricket'`, (alterErr) => {
+          if (alterErr) console.log('Note: Could not add sport to seasons:', alterErr.message);
+          else console.log('✅ Added sport column to seasons table');
+        });
+      } else {
+        console.log('✅ seasons.sport column already exists');
       }
     });
 
@@ -1466,10 +1486,11 @@ app.post('/api/admin/cricbuzz/import-season', requireRole('admin'), (req, res) =
 
 // Admin endpoints: create season
 app.post('/api/admin/seasons', requireRole('admin'), (req, res) => {
-  const { name } = req.body;
+  const { name, sport } = req.body;
   if (!name) return res.status(400).json({ error: 'name required' });
+  const sportValue = (sport === 'football') ? 'football' : 'cricket';
   const db = openDb();
-  db.run('INSERT INTO seasons (name) VALUES (?)', [name], function(err) {
+  db.run('INSERT INTO seasons (name, sport) VALUES (?, ?)', [name, sportValue], function(err) {
     db.close();
     if (err) return res.status(500).json({ error: 'DB error' });
     res.status(201).json({ id: this.lastID });
@@ -1479,11 +1500,12 @@ app.post('/api/admin/seasons', requireRole('admin'), (req, res) => {
 // Admin: update season
 app.put('/api/admin/seasons/:id', requireRole('admin'), (req, res) => {
   const id = Number(req.params.id);
-  const { name } = req.body;
+  const { name, sport } = req.body;
   if (!name) return res.status(400).json({ error: 'name required' });
+  const sportValue = (sport === 'football') ? 'football' : 'cricket';
 
   const db = openDb();
-  db.run('UPDATE seasons SET name = ? WHERE id = ?', [name, id], function(err) {
+  db.run('UPDATE seasons SET name = ?, sport = ? WHERE id = ?', [name, sportValue, id], function(err) {
     db.close();
     if (err) return res.status(500).json({ error: 'DB error' });
     if (this.changes === 0) return res.status(404).json({ error: 'Season not found' });
@@ -3531,9 +3553,20 @@ app.post('/api/admin/upload-matches', requireRole('admin'), (req, res) => {
 
   const db = openDb();
   const lines = csvData.trim().split('\n').slice(1); // skip header
+  // Normalize DD/MM/YYYY or D/M/YYYY to YYYY-MM-DD so parsers handle it consistently
+  function normalizeDateStr(d) {
+    const slash = d.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (slash) {
+      const dd = slash[1].padStart(2, '0');
+      const mm = slash[2].padStart(2, '0');
+      return `${slash[3]}-${mm}-${dd}`;
+    }
+    return d; // already in another format, leave as-is
+  }
+
   const insertMatch = (date, venue, team1, team2, time) => new Promise((resolve, reject) => {
     // Combine date and time into scheduled_at
-    const scheduled_at = `${date}T${time}`;
+    const scheduled_at = `${normalizeDateStr(date)}T${time}`;
     db.run('INSERT INTO matches (season_id, home_team, away_team, scheduled_at, venue) VALUES (?, ?, ?, ?, ?)',
       [seasonId, team1, team2, scheduled_at, venue], function(err) {
         if (err) return reject(err);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,9 +8,9 @@
     <link rel="apple-touch-icon" href="/pwa-192x192.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <meta name="apple-mobile-web-app-title" content="Cricket Mela">
-    <title>Cricket Mela</title>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🏏</text></svg>">
+    <meta name="apple-mobile-web-app-title" content="Sports Mela">
+    <title>Sports Mela</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚽</text></svg>">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,7 +10,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Sports Mela">
     <title>Sports Mela</title>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⚽</text></svg>">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>⭐</text></svg>">
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/Admin.jsx
+++ b/frontend/src/Admin.jsx
@@ -31,6 +31,7 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
   const [seasonBalancesLoading, setSeasonBalancesLoading] = useState({})
   const [expandedUserRows, setExpandedUserRows] = useState({})
   const [newSeason, setNewSeason] = useState('')
+  const [newSeasonSport, setNewSeasonSport] = useState('cricket')
   const [newUser, setNewUser] = useState({ username: '', password: '', role: 'picker', balance: 500, display_name: '', email: '', season_ids: [] })
   const [csvInput, setCsvInput] = useState('')
   const [selectedSeason, setSelectedSeason] = useState('')
@@ -154,14 +155,22 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
       monthIndex = parseInt(isoDate[2], 10) - 1
       day = parseInt(isoDate[3], 10)
     } else {
-      const dmy = datePart.match(/^(\d{1,2})-([A-Za-z]{3})-(\d{2}|\d{4})$/)
-      if (!dmy) return null
-      day = parseInt(dmy[1], 10)
-      const monthKey = dmy[2].toLowerCase()
-      if (monthMap[monthKey] === undefined) return null
-      monthIndex = monthMap[monthKey]
-      const yearRaw = dmy[3]
-      year = yearRaw.length === 2 ? 2000 + parseInt(yearRaw, 10) : parseInt(yearRaw, 10)
+      // Handle DD/MM/YYYY or D/M/YYYY (slash-separated, day first)
+      const slashDmy = datePart.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/)
+      if (slashDmy) {
+        day = parseInt(slashDmy[1], 10)
+        monthIndex = parseInt(slashDmy[2], 10) - 1
+        year = parseInt(slashDmy[3], 10)
+      } else {
+        const dmy = datePart.match(/^(\d{1,2})-([A-Za-z]{3})-(\d{2}|\d{4})$/)
+        if (!dmy) return null
+        day = parseInt(dmy[1], 10)
+        const monthKey = dmy[2].toLowerCase()
+        if (monthMap[monthKey] === undefined) return null
+        monthIndex = monthMap[monthKey]
+        const yearRaw = dmy[3]
+        year = yearRaw.length === 2 ? 2000 + parseInt(yearRaw, 10) : parseInt(yearRaw, 10)
+      }
     }
 
     const timePart = timePartRaw.trim()
@@ -178,6 +187,10 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
     }
 
     if (isoDate && !ampm) {
+      return new Date(Date.UTC(year, monthIndex, day, hour, minute, second, 0))
+    }
+    // For slash/dmy dates: 24h time (no AM/PM) means GMT/UTC; AM/PM means local time (cricket CSVs in IST)
+    if (!ampm) {
       return new Date(Date.UTC(year, monthIndex, day, hour, minute, second, 0))
     }
     return new Date(year, monthIndex, day, hour, minute, second, 0)
@@ -491,10 +504,11 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
   async function addSeason() {
     if (!newSeason) return toast('warning', 'Missing Input', 'Enter season name')
     try {
-      await axios.post('/api/admin/seasons', { name: newSeason }, {
+      await axios.post('/api/admin/seasons', { name: newSeason, sport: newSeasonSport }, {
         headers: { 'x-user': user?.username || 'admin' }
       })
       setNewSeason('')
+      setNewSeasonSport('cricket')
       fetchSeasons()
       toast('success', 'Success', 'Season created successfully')
     } catch (e) {
@@ -706,7 +720,8 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
       show: true,
       season: season,
       formData: {
-        name: season.name
+        name: season.name,
+        sport: season.sport || 'cricket'
       }
     })
   }
@@ -718,7 +733,7 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
     }
     try {
       await axios.put(`/api/admin/seasons/${editSeasonModal.season.id}`,
-        { name: editSeasonModal.formData.name },
+        { name: editSeasonModal.formData.name, sport: editSeasonModal.formData.sport || 'cricket' },
         { headers: { 'x-user': user?.username || 'admin' } }
       )
       toast('success', 'Success', 'Season updated successfully')
@@ -1145,8 +1160,12 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
 
           <section style={{background: 'rgba(255,255,255,0.72)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', borderRadius: '16px', padding: '22px', marginBottom: '20px', boxShadow: '0 4px 24px rgba(0,0,0,0.08)', border: '1px solid rgba(255,255,255,0.55)'}}>
             <h3 style={{color: '#1a1a1a', marginTop: '0', marginBottom: '15px', fontSize: '18px', fontWeight: 'bold'}}>Create Season</h3>
-            <div style={{display: 'flex', gap: '10px'}}>
-              <input value={newSeason} onChange={e => setNewSeason(e.target.value)} placeholder="Season name" style={{flex: 1, padding: '12px 15px', border: '1px solid #ddd', borderRadius: '25px', fontSize: '14px', outline: 'none'}} onFocus={(e) => e.target.style.borderColor = '#2ecc71'} onBlur={(e) => e.target.style.borderColor = '#ddd'} />
+            <div style={{display: 'flex', gap: '10px', flexWrap: 'wrap'}}>
+              <input value={newSeason} onChange={e => setNewSeason(e.target.value)} placeholder="Season name" style={{flex: 1, minWidth: '140px', padding: '12px 15px', border: '1px solid #ddd', borderRadius: '25px', fontSize: '14px', outline: 'none'}} onFocus={(e) => e.target.style.borderColor = '#2ecc71'} onBlur={(e) => e.target.style.borderColor = '#ddd'} />
+              <select value={newSeasonSport} onChange={e => setNewSeasonSport(e.target.value)} style={{padding: '12px 15px', border: '1px solid #ddd', borderRadius: '25px', fontSize: '14px', outline: 'none', cursor: 'pointer', background: 'white'}}>
+                <option value="cricket">🏏 Cricket</option>
+                <option value="football">⚽ Football</option>
+              </select>
               <button onClick={addSeason} style={{padding: '12px 30px', backgroundColor: '#2ecc71', color: 'white', border: 'none', borderRadius: '25px', cursor: 'pointer', fontWeight: 'bold'}} onMouseOver={(e) => e.target.style.backgroundColor = '#27ae60'} onMouseOut={(e) => e.target.style.backgroundColor = '#2ecc71'}>Create</button>
             </div>
           </section>
@@ -1702,6 +1721,14 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
           {!isSuperuser && (
             <section style={{background: 'rgba(255,255,255,0.72)', backdropFilter: 'blur(12px)', WebkitBackdropFilter: 'blur(12px)', borderRadius: '16px', padding: '22px', marginBottom: '20px', boxShadow: '0 4px 24px rgba(0,0,0,0.08)', border: '1px solid rgba(255,255,255,0.55)'}}>
               <h3 style={{color: '#1a1a1a', marginTop: '0', marginBottom: '15px', fontSize: '18px', fontWeight: 'bold'}}>Bulk Upload CSV Matches</h3>
+              <div style={{marginBottom: '12px', display: 'flex', gap: '10px', alignItems: 'center', flexWrap: 'wrap'}}>
+                <label style={{fontWeight: 'bold', color: '#1a1a1a', whiteSpace: 'nowrap'}}>Upload to Season:</label>
+                <select value={selectedSeason} onChange={e => { setSelectedSeason(e.target.value); fetchMatches(e.target.value) }}
+                  style={{padding: '10px 15px', border: '2px solid #2ecc71', borderRadius: '25px', fontSize: '14px', outline: 'none', cursor: 'pointer', flex: 1, maxWidth: '280px', fontWeight: '600', background: 'white'}}>
+                  <option value="">-- Select Season --</option>
+                  {seasons.map(s => <option key={s.id} value={s.id}>{s.sport === 'football' ? '⚽' : '🏏'} {s.name}</option>)}
+                </select>
+              </div>
               <small style={{display: 'block', marginBottom: '10px', color: '#666'}}>Format: Date,Venue,Team 1,Team 2,Time</small>
               <textarea
                 value={csvInput}
@@ -2356,6 +2383,13 @@ export default function Admin({ user, initialTab, onTabChange, addToast, refresh
             <div style={{margin: '15px 0'}}>
               <label style={{display: 'block', marginBottom: '5px', fontWeight: 'bold'}}>Season Name:</label>
               <input type="text" value={editSeasonModal.formData.name} onChange={e => setEditSeasonModal({...editSeasonModal, formData: {...editSeasonModal.formData, name: e.target.value}})} style={{width: '100%', padding: '8px', boxSizing: 'border-box', borderRadius: '4px', border: '1px solid #ddd'}} />
+            </div>
+            <div style={{margin: '15px 0'}}>
+              <label style={{display: 'block', marginBottom: '5px', fontWeight: 'bold'}}>Sport:</label>
+              <select value={editSeasonModal.formData.sport || 'cricket'} onChange={e => setEditSeasonModal({...editSeasonModal, formData: {...editSeasonModal.formData, sport: e.target.value}})} style={{width: '100%', padding: '8px', boxSizing: 'border-box', borderRadius: '4px', border: '1px solid #ddd', cursor: 'pointer'}}>
+                <option value="cricket">🏏 Cricket</option>
+                <option value="football">⚽ Football</option>
+              </select>
             </div>
             <div style={{display: 'flex', gap: '10px', justifyContent: 'flex-end', marginTop: '20px'}}>
               <button onClick={() => setEditSeasonModal({show: false, season: null, formData: {}})} style={{padding: '8px 16px', backgroundColor: '#ccc', border: 'none', borderRadius: '4px', cursor: 'pointer'}}>Cancel</button>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -288,7 +288,7 @@ export default function App() {
 
             {/* Brand */}
             <div className="header-brand" style={{display:'flex',alignItems:'center',gap:'8px',whiteSpace:'nowrap'}}>
-              <span style={{fontSize:'clamp(20px,3.5vw,28px)',lineHeight:1,filter:'drop-shadow(0 0 6px rgba(255,180,0,0.5))'}}>⚽</span>
+              <span style={{fontSize:'clamp(20px,3.5vw,28px)',lineHeight:1,filter:'drop-shadow(0 0 6px rgba(255,180,0,0.5))'}}>⭐</span>
               <span style={{
                 fontFamily:"'Poppins',sans-serif",
                 fontSize:'clamp(18px,3.5vw,26px)',

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -97,6 +97,7 @@ export default function App() {
 
   const [toasts, setToasts] = useState([])
   const [refreshTrigger, setRefreshTrigger] = useState(0)
+  const [seasonSport, setSeasonSport] = useState('cricket')
   const [headerBalance, setHeaderBalance] = useState(null)
 
   // Fetch overall balance for header chip
@@ -189,7 +190,7 @@ export default function App() {
         const parsed=JSON.parse(decodeURIComponent(params.get('user')||''))
         localStorage.setItem('user',JSON.stringify(parsed));setUser(parsed)
         window.history.replaceState({ page:'seasons', seasonId:null, adminTab:'season' },'','/')
-        toast('success',`Welcome, ${parsed.display_name||parsed.username}! 🏏`,'Ready to make your picks?')
+        toast('success',`Welcome, ${parsed.display_name||parsed.username}! �`,'Ready to make your picks?')
       }catch(e){console.error(e)}
     }
     if(params.get('error')==='pending_approval'){
@@ -287,7 +288,7 @@ export default function App() {
 
             {/* Brand */}
             <div className="header-brand" style={{display:'flex',alignItems:'center',gap:'8px',whiteSpace:'nowrap'}}>
-              <span style={{fontSize:'clamp(20px,3.5vw,28px)',lineHeight:1,filter:'drop-shadow(0 0 6px rgba(255,180,0,0.5))'}}>🏏</span>
+              <span style={{fontSize:'clamp(20px,3.5vw,28px)',lineHeight:1,filter:'drop-shadow(0 0 6px rgba(255,180,0,0.5))'}}>⚽</span>
               <span style={{
                 fontFamily:"'Poppins',sans-serif",
                 fontSize:'clamp(18px,3.5vw,26px)',
@@ -297,7 +298,7 @@ export default function App() {
                 backgroundClip:'text', color:'transparent',
                 filter:'drop-shadow(0 0 10px rgba(255,180,0,0.4))',
                 lineHeight:1.2,
-              }}>Cricket Mela</span>
+              }}>Sports Mela</span>
               <button
                 className="header-sparkle-btn"
                 onClick={() => celebrateVictory()}
@@ -446,11 +447,11 @@ export default function App() {
 
       <main className={disclaimerHidden ? '' : 'disclaimer-visible'}>
         {!user ? (
-          <Login onLogin={u=>{ setUser(u); toast('success',`Welcome, ${u.display_name||u.username}! 🏏`,'Ready to make your picks?') }}/>
+          <Login onLogin={u=>{ setUser(u); toast('success',`Welcome, ${u.display_name||u.username}! �`,'Ready to make your picks?') }}/>
         ):(
           <>
-            {page==='seasons'    && <Seasons user={user} onSelect={id=>{setSeasonId(id);setPage('matches')}} refreshTrigger={refreshTrigger}/>}
-            {page==='matches'    && seasonId && <Matches seasonId={seasonId} user={user} refreshUser={u=>setUser(u)} refreshTrigger={refreshTrigger}/>}
+            {page==='seasons'    && <Seasons user={user} onSelect={(id, sport) => { setSeasonId(id); setSeasonSport(sport || 'cricket'); setPage('matches') }} refreshTrigger={refreshTrigger}/>}
+            {page==='matches'    && seasonId && <Matches seasonId={seasonId} sport={seasonSport} user={user} refreshUser={u=>setUser(u)} refreshTrigger={refreshTrigger}/>}
             {page==='admin'      && <Admin user={user} initialTab={adminTab} onTabChange={setAdminTab} addToast={addToast} refreshTrigger={refreshTrigger}/>}
             {page==='history'    && <VoteHistory user={user} refreshTrigger={refreshTrigger}/>}
             {page==='analytics'  && <Analytics user={user} refreshTrigger={refreshTrigger}/>}
@@ -463,10 +464,10 @@ export default function App() {
 
       <footer className={`disclaimer-ribbon${disclaimerHidden ? ' hidden' : ''}`}>
         <span style={{color:'#ffe082',fontWeight:'bold'}}>⚠️ Disclaimer:</span>{' '}
-        Cricket Mela is a <strong style={{color:'#fff'}}>fun prediction game only</strong> — no real money involved.
+        Sports Mela is a <strong style={{color:'#fff'}}>fun prediction game only</strong> — no real money involved.
         Virtual points have no monetary value and cannot be exchanged for cash.
         This platform must <strong style={{color:'#ff6b6b'}}>not</strong> be used for real-money gambling.
-        &nbsp;|&nbsp; 🏏 Play responsibly &amp; enjoy the game!
+        &nbsp;|&nbsp; 🏆 Play responsibly &amp; enjoy the game!
       </footer>
     </div>
     </>

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -253,7 +253,7 @@ export default function Login({ onLogin }) {
           background:'linear-gradient(180deg, #FFD700 0%, #FF8C00 50%, #FF4500 100%)',
           WebkitBackgroundClip:'text', WebkitTextFillColor:'transparent',
           filter:'drop-shadow(0 2px 10px rgba(255,160,0,0.6))',
-        }}>🏏 CRICKET MELA</h1>
+        }}>⭐ SPORTS MELA</h1>
         <div style={{ fontSize:'clamp(11px, 2vw, 13px)', color:'#acd8ff',
           letterSpacing:'4px', textTransform:'uppercase', marginTop:'5px', fontWeight:'600' }}>
           IPL &amp; International Prediction Game
@@ -580,7 +580,7 @@ export default function Login({ onLogin }) {
           border:'1px solid rgba(255,200,50,0.22)',
           fontSize:'10.5px', color:'rgba(255,240,180,0.8)', lineHeight:'1.6', textAlign:'center',
         }}>
-          ⚠️ <strong style={{ color:'#f9d423' }}>Disclaimer:</strong> Cricket Mela is a{' '}
+          ⚠️ <strong style={{ color:'#f9d423' }}>Disclaimer:</strong> Sports Mela is a{' '}
           <strong>fun prediction game only</strong>. No real money involved.
           Points are virtual with no monetary value. Must{' '}
           <strong style={{ color:'#ff7070' }}>not</strong> be used for real-money gambling.

--- a/frontend/src/Matches.jsx
+++ b/frontend/src/Matches.jsx
@@ -96,7 +96,7 @@ function NextMatchCountdown({ matches, parseMatchDateTime, seasonBalance }) {
   )
 }
 
-export default function Matches({ seasonId, user, refreshUser, refreshTrigger }) {
+export default function Matches({ seasonId, sport, user, refreshUser, refreshTrigger }) {
   const [matches, setMatches] = useState([])
   const [loading, setLoading] = useState(true)
   const [votes, setVotes] = useState({})
@@ -259,14 +259,22 @@ export default function Matches({ seasonId, user, refreshUser, refreshTrigger })
       monthIndex = parseInt(isoDate[2], 10) - 1
       day = parseInt(isoDate[3], 10)
     } else {
-      const dmy = datePart.match(/^(\d{1,2})-([A-Za-z]{3})-(\d{2}|\d{4})$/)
-      if (!dmy) return null
-      day = parseInt(dmy[1], 10)
-      const monthKey = dmy[2].toLowerCase()
-      if (monthMap[monthKey] === undefined) return null
-      monthIndex = monthMap[monthKey]
-      const yearRaw = dmy[3]
-      year = yearRaw.length === 2 ? 2000 + parseInt(yearRaw, 10) : parseInt(yearRaw, 10)
+      // Handle DD/MM/YYYY or D/M/YYYY (slash-separated, day first)
+      const slashDmy = datePart.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/)
+      if (slashDmy) {
+        day = parseInt(slashDmy[1], 10)
+        monthIndex = parseInt(slashDmy[2], 10) - 1
+        year = parseInt(slashDmy[3], 10)
+      } else {
+        const dmy = datePart.match(/^(\d{1,2})-([A-Za-z]{3})-(\d{2}|\d{4})$/)
+        if (!dmy) return null
+        day = parseInt(dmy[1], 10)
+        const monthKey = dmy[2].toLowerCase()
+        if (monthMap[monthKey] === undefined) return null
+        monthIndex = monthMap[monthKey]
+        const yearRaw = dmy[3]
+        year = yearRaw.length === 2 ? 2000 + parseInt(yearRaw, 10) : parseInt(yearRaw, 10)
+      }
     }
 
     const timePart = timePartRaw.trim()
@@ -283,6 +291,10 @@ export default function Matches({ seasonId, user, refreshUser, refreshTrigger })
     }
 
     if (isoDate && !ampm) {
+      return new Date(Date.UTC(year, monthIndex, day, hour, minute, second, 0))
+    }
+    // For slash/dmy dates: 24h time (no AM/PM) means GMT/UTC; AM/PM means local time (cricket CSVs in IST)
+    if (!ampm) {
       return new Date(Date.UTC(year, monthIndex, day, hour, minute, second, 0))
     }
     return new Date(year, monthIndex, day, hour, minute, second, 0)
@@ -537,14 +549,14 @@ export default function Matches({ seasonId, user, refreshUser, refreshTrigger })
                     ) : (
                       <div>
                         <div style={{display: 'flex', gap: '8px', marginBottom: '10px'}}>
-                          {[m.home_team, m.away_team].map(team => {
+                          {[m.home_team, ...(sport === 'football' ? ['Draw'] : []), m.away_team].map(team => {
                             const selected = votes[m.id]?.team === team
                             return (
                               <label key={team} style={{flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '10px 6px', borderRadius: '10px', cursor: 'pointer', border: `2px solid ${selected ? '#667eea' : '#e2e8f0'}`, background: selected ? 'rgba(102,126,234,0.12)' : 'white', fontSize: '12px', fontWeight: '700', color: selected ? '#667eea' : '#4a5568', textAlign: 'center', transition: 'all 0.15s ease'}}>
                                 <input type="radio" name={`vote-${m.id}`} value={team} checked={selected}
                                   onChange={e => { dirtyVotes.current.add(m.id); setVotes({...votes, [m.id]: {...(votes[m.id] || {}), team: e.target.value}}) }}
                                   style={{display: 'none'}} />
-                                {team}
+                                {team === 'Draw' ? '🤝 Draw' : team}
                               </label>
                             )
                           })}
@@ -623,6 +635,14 @@ export default function Matches({ seasonId, user, refreshUser, refreshTrigger })
                                 disabled={votingDisabled} style={{accentColor: '#667eea'}} />
                               <span style={{fontWeight: '500'}}>{m.home_team}</span>
                             </label>
+                            {sport === 'football' && (
+                              <label style={{display: 'flex', alignItems: 'center', gap: '6px', cursor: 'pointer', fontSize: '12px'}}>
+                                <input type="radio" name={`vote-${m.id}`} value="Draw" checked={votes[m.id]?.team === 'Draw'}
+                                  onChange={e => { dirtyVotes.current.add(m.id); setVotes({...votes, [m.id]: {...(votes[m.id] || {}), team: e.target.value}}) }}
+                                  disabled={votingDisabled} style={{accentColor: '#667eea'}} />
+                                <span style={{fontWeight: '500'}}>🤝 Draw</span>
+                              </label>
+                            )}
                             <label style={{display: 'flex', alignItems: 'center', gap: '6px', cursor: 'pointer', fontSize: '12px'}}>
                               <input type="radio" name={`vote-${m.id}`} value={m.away_team} checked={votes[m.id]?.team === m.away_team}
                                 onChange={e => { dirtyVotes.current.add(m.id); setVotes({...votes, [m.id]: {...(votes[m.id] || {}), team: e.target.value}}) }}

--- a/frontend/src/Seasons.jsx
+++ b/frontend/src/Seasons.jsx
@@ -90,10 +90,10 @@ export default function Seasons({ user, onSelect, refreshTrigger }) {
 
   return (
     <div style={styles.container}>
-      <h2 style={styles.title}>🏆 Cricket Seasons</h2>
+      <h2 style={styles.title}>🏆 My Seasons</h2>
       {seasons.length === 0 ? (
         <div style={styles.emptyState}>
-          <div style={{fontSize: '60px', marginBottom: '20px'}}>🏏</div>
+          <div style={{fontSize: '60px', marginBottom: '20px'}}>🏆</div>
           <p style={{fontSize: '18px'}}>No seasons available yet</p>
         </div>
       ) : (
@@ -104,13 +104,13 @@ export default function Seasons({ user, onSelect, refreshTrigger }) {
               style={styles.card(hoveredId === s.id)}
               onMouseEnter={() => setHoveredId(s.id)}
               onMouseLeave={() => setHoveredId(null)}
-              onClick={() => onSelect(s.id)}
+              onClick={() => onSelect(s.id, s.sport || 'cricket')}  
             >
               <div style={styles.badge(hoveredId === s.id)}>
                 LIVE
               </div>
               <div style={styles.iconContainer}>
-                🏏
+                {s.sport === 'football' ? '⚽' : '🏏'}
               </div>
               <div style={styles.seasonName}>
                 {s.name}


### PR DESCRIPTION
- Add sport column to seasons table (cricket/football) with DB migration
- Rebrand app title, header, and footer from Cricket Mela to Sports Mela
- Season cards show soccer ball for football, cricket for cricket based on sport field
- Admin season create/edit forms include sport dropdown
- Matches component shows Draw option for football seasons
- Fix DD/MM/YYYY (slash) date format parsing in backend and frontend
- Fix 24h times (no AM/PM) treated as UTC for correct timezone conversion
- Normalise slash dates in CSV upload before storing to DB
- CSV upload section has its own season selector to prevent wrong-season uploads